### PR TITLE
export name to allow usage of AngularApollo

### DIFF
--- a/src/apollo.provider.ts
+++ b/src/apollo.provider.ts
@@ -45,4 +45,4 @@ class ApolloProvider implements angular.IServiceProvider {
 }
 
 export default angular.module('angular-apollo', [])
-  .provider('apollo', new ApolloProvider);
+  .provider('apollo', new ApolloProvider).name;


### PR DESCRIPTION
export name to allow usage of AngularApollo as variable and not string.
otherwise in some cases webpack will mark it as unused and remove it.
import AngularApollo from 'angular1-apollo';   --- this was marked as unused