### PR TITLE
docs: add live example to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Use your GraphQL server data in your Angular 1.0 app, with the [Apollo Client](h
 
 * [Install](#install)
 * [Development](#development)
+* [Live Example](https://codesandbox.io/s/l4r87nqj5z)
 
 ## Install
 


### PR DESCRIPTION
Hi, this adds a very basic live example to the docs. It seems like it could be good place for people looking to get started. It pretty much follows the query example already in the docs. You could also change the url to a fork of this code sandbox and fork the Apollo Launchpad if you prefer to have control over these. Thanks!