### PR TITLE
fix: fix ChromeHeadless Karma tests

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,7 +14,13 @@ module.exports = function(config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    customLaunchers: {
+      ChromeHeadlessNoSandbox: {
+        base: 'Chrome',
+        flags: ['--no-sandbox', '--headless', '--disable-gpu', '--remote-debugging-port=9222']
+      }
+    },
+    browsers: ['ChromeHeadlessNoSandbox'],
     singleRun: false,
     concurrency: Infinity,
   });


### PR DESCRIPTION
This uses the unsandboxed version to fix Chrome Headless tests.